### PR TITLE
Updated backend with dynamoDB table for terraform state lock

### DIFF
--- a/staging/us-east-2/provider.tf
+++ b/staging/us-east-2/provider.tf
@@ -10,6 +10,7 @@ terraform {
     bucket = "johny-cs2-terraform"
     key    = "staging/terraform.tfstate"
     region = "us-east-2"
+    dynamodb_table = "cs2-terraform-state-lock"
   }
 }
 


### PR DESCRIPTION
I have updated backend block by adding a dynamodb_table for terraform state lock.

backend "s3" {
    bucket = "johny-cs2-terraform"
    key    = "staging/terraform.tfstate"
    region = "us-east-2"
    **dynamodb_table = "cs2-terraform-state-lock"**
  }