### PR TITLE
Added the remaining terraform code for the staging infra module

### DIFF
--- a/staging/us-east-2/data.tf
+++ b/staging/us-east-2/data.tf
@@ -1,0 +1,17 @@
+####### DNS Zone Data Lookup
+data "aws_route53_zone" "johnyfoster_zone" {
+  name = "johnyfoster.com."
+}
+
+####### Certificate Data Lookup
+data "aws_acm_certificate" "amazon_issued" {
+  domain      = "*.johnyfoster.com"
+  types       = ["AMAZON_ISSUED"]
+  most_recent = true
+}
+
+output "certificate_arn" {
+  value = data.aws_acm_certificate.amazon_issued.arn
+}
+
+# data.aws_acm_certificate.amazon_issued.arn

--- a/staging/us-east-2/locals.tf
+++ b/staging/us-east-2/locals.tf
@@ -203,3 +203,30 @@ locals {
   resource_type                        = "instance"
   user_data                            = filebase64("web.sh")
 }
+
+##########################################################################
+############# Locals for Target Group and Load balancer
+##########################################################################
+
+locals {
+  lb_proto_http = "HTTP"
+  load_balancer_type = "application"
+  lb_proto_https = "HTTPS"
+  lb_port_http = "80"
+  lb_port_https = "443"
+  lb_ssl_policy = "ELBSecurityPolicy-2016-08"
+}
+
+##########################################################################
+############# Locals for DNS records
+##########################################################################
+
+locals {
+  dns_aliases = {
+    "alias1" = "www.${local.env}.johnyfoster.com"
+    "alias2" ="${local.env}.johnyfoster.com"
+  }
+
+  zone_id = data.aws_route53_zone.johnyfoster_zone.id
+  certificate_arn = data.aws_acm_certificate.amazon_issued.arn
+}

--- a/staging/us-east-2/locals.tf
+++ b/staging/us-east-2/locals.tf
@@ -202,6 +202,12 @@ locals {
   key_pairs_name                       = "main-us-east-2"
   resource_type                        = "instance"
   user_data                            = filebase64("web.sh")
+
+  desired_capacity    = 2
+  max_size            = 4
+  min_size            = 1
+  health_check_grace_period = 10
+  health_check_type         = "ELB"
 }
 
 ##########################################################################

--- a/staging/us-east-2/modules/main.tf
+++ b/staging/us-east-2/modules/main.tf
@@ -288,11 +288,11 @@ resource "aws_autoscaling_group" "asg" {
   name = "${var.env}-asg"
   target_group_arns   = [aws_lb_target_group.tg.arn]
   vpc_zone_identifier = [ for subnet in aws_subnet.private_subnets : subnet.id]
-  desired_capacity    = 2
-  max_size            = 4
-  min_size            = 1
-  health_check_grace_period = 10
-  health_check_type         = "ELB"
+  desired_capacity    = var.desired_capacity
+  max_size            = var.max_size
+  min_size            = var.min_size
+  health_check_grace_period = var.health_check_grace_period
+  health_check_type         = var.health_check_type
 
   launch_template {
     id      = aws_launch_template.lt.id
@@ -306,7 +306,7 @@ resource "aws_autoscaling_group" "asg" {
 
 resource "aws_lb_target_group" "tg" {
   name     = "${var.env}-80-tg"
-  port     = 80
+  port     = var.lb_port_http
   protocol = var.lb_proto_http
   vpc_id   = aws_vpc.vpc.id
 

--- a/staging/us-east-2/modules/variables.tf
+++ b/staging/us-east-2/modules/variables.tf
@@ -133,7 +133,7 @@ variable "all_ipv4_cidr" {
 }
 
 ##########################################################################
-############# Autoscaling Grop and Launch Template Variables
+############# Autoscaling Group and Launch Template Variables
 ##########################################################################
 
 variable "image_id" {
@@ -157,5 +157,49 @@ variable "resource_type" {
 }
 
 variable "user_data" {
+  type = string
+}
+
+##########################################################################
+############# Target Group and Loab Balancer variable
+##########################################################################
+
+variable "lb_proto_http" {
+  type    = string
+}
+
+variable "lb_proto_https" {
+  type    = string
+}
+
+variable "lb_port_http" {
+  type    = string
+}
+
+variable "lb_port_https" {
+  type    = string
+}
+
+variable "lb_ssl_policy" {
+  type    = string
+}
+
+variable "load_balancer_type" {
+  type = string
+}
+
+##########################################################################
+############# DNS record variables
+##########################################################################
+
+variable "dns_aliases" {
+  type = map(string)
+}
+
+variable "zone_id" {
+  type = string
+}
+
+variable "certificate_arn" {
   type = string
 }

--- a/staging/us-east-2/modules/variables.tf
+++ b/staging/us-east-2/modules/variables.tf
@@ -160,6 +160,24 @@ variable "user_data" {
   type = string
 }
 
+variable "desired_capacity" {
+  type = number
+}
+
+variable "max_size" {
+  type = number
+}
+
+variable "min_size" {
+  type = number
+}
+variable "health_check_grace_period" {
+  type = number
+}
+variable "health_check_type" {
+  type = string
+}
+
 ##########################################################################
 ############# Target Group and Loab Balancer variable
 ##########################################################################

--- a/staging/us-east-2/vpc.tf
+++ b/staging/us-east-2/vpc.tf
@@ -32,4 +32,9 @@ module "staging" {
   zone_id = local.zone_id
   certificate_arn = local.certificate_arn
   dns_aliases = local.dns_aliases
+  desired_capacity    = local.desired_capacity
+  max_size            = local.max_size
+  min_size            = local.min_size
+  health_check_grace_period = local.health_check_grace_period
+  health_check_type         = local.health_check_type
 }

--- a/staging/us-east-2/vpc.tf
+++ b/staging/us-east-2/vpc.tf
@@ -23,4 +23,13 @@ module "staging" {
   key_pairs_name                       = local.key_pairs_name
   resource_type                        = local.resource_type
   user_data                            = local.user_data
+  lb_proto_http = local.lb_proto_http
+  load_balancer_type = local.load_balancer_type
+  lb_proto_https = local.lb_proto_https
+  lb_port_http = local.lb_port_http
+  lb_port_https = local.lb_port_https
+  lb_ssl_policy = local.lb_ssl_policy
+  zone_id = local.zone_id
+  certificate_arn = local.certificate_arn
+  dns_aliases = local.dns_aliases
 }


### PR DESCRIPTION
This PR is to add the remaining terraform code for the staging infra module. The terraform code for the following were added and the whole staging infra built from the module and successfully provisioned .

- Target Group and ALB
- ALB listener rules
- ALB Forwarding Redirecting HTTP to HTTPS
- DNS Records