### PR TITLE
Updated the source to point to the staging public module in github

### DIFF
--- a/staging/us-east-2/vpc.tf
+++ b/staging/us-east-2/vpc.tf
@@ -3,7 +3,8 @@
 ##########################################################################
 
 module "staging" {
-  source                               = "./modules"
+  # source                               = "./modules"
+  source = "github.com/fojiglobal/johny-tf-module//staging?ref=v1.0.1"
   vpc_cidr                             = local.vpc_cidr
   env                                  = local.env
   provisioner                          = local.provisioner


### PR DESCRIPTION
This PR is to update the source  in the terraform code for the staging infrastructure to point this time to the staging public module published in GitHub though https://github.com/fojiglobal/johny-tf-modules/pull/2.